### PR TITLE
Add an mzed_transpose function

### DIFF
--- a/bench/Makefile.am
+++ b/bench/Makefile.am
@@ -21,7 +21,8 @@ BENCH = bench_multiplication \
         bench_elimination \
         bench_smallops \
         bench_trsm \
-        bench_ple
+        bench_ple \
+        bench_transpose
 
 
 CPUCYCLES_DIR = cpucycles-20060326
@@ -39,6 +40,7 @@ bench_elimination_SOURCES = bench_elimination.c benchmarking.c benchmarking.h
 bench_multiplication_SOURCES = bench_multiplication.c benchmarking.c benchmarking.h
 bench_ple_SOURCES = bench_ple.c benchmarking.c benchmarking.h
 bench_smallops_SOURCES = bench_smallops.c benchmarking.c benchmarking.h
+bench_transpose_SOURCES = bench_transpose.c benchmarking.c benchmarking.h
 bench_trsm_SOURCES = bench_trsm.c benchmarking.c benchmarking.h
 
 BUILT_SOURCES = cpucycles.h

--- a/bench/bench_transpose.c
+++ b/bench/bench_transpose.c
@@ -1,0 +1,87 @@
+#include <m4rie/m4rie.h>
+#include "cpucycles.h"
+#include "benchmarking.h"
+
+struct transpose_params {
+  rci_t e;
+  rci_t m;
+  rci_t n;
+  char const *algorithm;
+};
+
+int run_mzed (void *_p, unsigned long long *data, int *data_len) {
+  struct transpose_params *p = (struct transpose_params *)_p;
+  *data_len = 2;
+
+  gf2e *ff = gf2e_init(irreducible_polynomials[p->e][1]);
+  
+  mzed_t *A = mzed_init(ff,p->m,p->n);
+  mzed_randomize(A);
+  mzed_t *B = mzed_init(ff,p->n,p->m);
+
+  data[0] = walltime(0);
+  data[1] = cpucycles();
+  
+  if (strcmp(p->algorithm, "optimised") == 0) {
+    B = mzed_transpose(B, A);
+  } else if (strcmp(p->algorithm, "naive") == 0) {
+    for (rci_t row = 0; row < A->nrows; row++) {
+      for (rci_t row = 0; row < A->nrows; row++) {
+        for (rci_t col = 0; col < A->ncols; col++) {
+          mzed_write_elem(B, col, row, mzed_read_elem(A, row, col));
+        }
+      }
+    }
+  } else {
+    m4ri_die("uknown algorithm '%s'\n.",p->algorithm);
+  }
+  
+  B = mzed_transpose(B, A);
+
+  data[1] = cpucycles() - data[1];
+  data[0] = walltime(data[0]);
+
+  mzed_free(A);
+  mzed_free(B);
+  gf2e_free(ff);
+  return 0;
+}
+
+void print_help() {
+  printf("bench_elimination:\n\n");
+  printf("REQUIRED\n");
+  printf("  e -- integer between 2 and 16\n");
+  printf("  m -- integer > 0, number of rows\n");
+  printf("  n -- integer > 0, number of columns\n");
+  printf("  algorithm -- optimised -- optimised transpose\n");
+  printf("               naive -- transfer element by element\n");
+  printf("\n");
+  bench_print_global_options(stdout);
+}
+
+int main(int argc, char **argv) {
+  global_options(&argc, &argv);
+  
+  if (argc < 4 || argc > 5) {
+    print_help();
+    m4ri_die("");
+  }
+  
+  struct transpose_params params;
+
+  params.e = atoi(argv[1]);
+  params.m = atoi(argv[2]);
+  params.n = atoi(argv[3]);
+  if (argc >= 5)
+    params.algorithm = argv[4];
+  else
+    params.algorithm = (char*)"default";
+
+  srandom(17);
+  unsigned long long data[2];
+  run_bench(run_mzed, (void*)&params, data, 2);
+
+  double cc_per_bit = (((double)data[1])/ ((double)params.m * (double)params.n * (double)params.e) );
+
+  printf("e: %2d, m: %5d, n: %5d, algo: %10s, cpu cycles: %10llu, cc/bit: %.5lf, wall time: %lf\n", params.e, params.m, params.n, params.algorithm, data[1], cc_per_bit, data[0] / 1000000.0);
+}

--- a/bench/bench_transpose.c
+++ b/bench/bench_transpose.c
@@ -26,14 +26,12 @@ int run_mzed (void *_p, unsigned long long *data, int *data_len) {
     B = mzed_transpose(B, A);
   } else if (strcmp(p->algorithm, "naive") == 0) {
     for (rci_t row = 0; row < A->nrows; row++) {
-      for (rci_t row = 0; row < A->nrows; row++) {
-        for (rci_t col = 0; col < A->ncols; col++) {
-          mzed_write_elem(B, col, row, mzed_read_elem(A, row, col));
-        }
+      for (rci_t col = 0; col < A->ncols; col++) {
+        mzed_write_elem(B, col, row, mzed_read_elem(A, row, col));
       }
     }
   } else {
-    m4ri_die("uknown algorithm '%s'\n.",p->algorithm);
+    m4ri_die("unknown algorithm '%s'\n.",p->algorithm);
   }
   
   B = mzed_transpose(B, A);
@@ -75,7 +73,7 @@ int main(int argc, char **argv) {
   if (argc >= 5)
     params.algorithm = argv[4];
   else
-    params.algorithm = (char*)"default";
+    params.algorithm = (char*)"optimised";
 
   srandom(17);
   unsigned long long data[2];

--- a/src/mzed.c
+++ b/src/mzed.c
@@ -221,7 +221,7 @@ mzed_t *mzed_transpose(mzed_t *DST, const mzed_t *A) {
     for (wi_t block = 0; block < DST->x->rowstride; block++) {
       word buf = mzd_read_bits(DST->x, col, block * m4ri_radix, m4ri_radix);
       if (row % row_divisor != 0) {
-        buf = elem >> (block*m4ri_radix - (row - 1) * A->w);
+        buf ^= elem >> (block*m4ri_radix - (row - 1) * A->w);
       }
       for (; row * A->w < (block + 1) * m4ri_radix; row++) {
         elem = mzd_read_bits(A->x, row, A->w * col, A->w);

--- a/src/mzed.c
+++ b/src/mzed.c
@@ -215,7 +215,7 @@ mzed_t *mzed_transpose(mzed_t *DST, const mzed_t *A) {
   if (A->nrows == 0 || A->ncols == 0)
     return DST;
   int const row_divisor = m4ri_radix / (A->w & (-A->w));
-  for (rci_t col = 0; col < A->nrows; col++) {
+  for (rci_t col = 0; col < A->ncols; col++) {
     word elem;
     rci_t row = 0;
     for (wi_t block = 0; block < DST->x->rowstride; block++) {

--- a/src/mzed.c
+++ b/src/mzed.c
@@ -210,7 +210,7 @@ mzed_t *mzed_transpose(mzed_t *DST, const mzed_t *A) {
   if (DST == NULL)
     DST = mzed_init(A->finite_field, A->ncols, A->nrows);
   if (DST->finite_field != A->finite_field || DST->nrows != A->ncols || DST->ncols != A->nrows) {
-    m4ri_die("mzed_copy: target matrix has wrong dimensions or base field.");
+    m4ri_die("mzed_transpose: target matrix has wrong dimensions or base field.");
   }
   if (A->nrows == 0 || A->ncols == 0)
     return DST;

--- a/src/mzed.h
+++ b/src/mzed.h
@@ -397,6 +397,14 @@ void mzed_randomize(mzed_t *A);
 mzed_t *mzed_copy(mzed_t *B, const mzed_t *A);
 
 /**
+ * \brief Transpose a matrix.
+ *
+ * \param DST Preallocated return matrix, may be NULL for automatic creation.
+ * \param A Matrix
+ */
+mzed_t *mzed_transpose(mzed_t *DST, const mzed_t *A);
+
+/**
  * \brief Return diagonal matrix with value on the diagonal.
  *
  * If the matrix is not square then the largest possible square

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,7 +6,7 @@ AM_LDFLAGS = ${M4RI_LIBS} -no-install
 
 EXTRA_DIST = testing.h
 
-TESTS = test_trsm test_elimination test_multiplication test_smallops test_ple
+TESTS = test_trsm test_elimination test_multiplication test_smallops test_ple test_transpose
 check_PROGRAMS = ${TESTS}
 
 all: ${TESTS}

--- a/tests/test_transpose.c
+++ b/tests/test_transpose.c
@@ -1,7 +1,7 @@
 #include "testing.h"
 
 int test_equality(gf2e *ff, rci_t m, rci_t n) {
-  int fail_ret = 0, bad_elem;
+  int fail_ret = 0;
   mzed_t *A0 = random_mzed_t(ff, m, n);
   mzed_t *A1 = mzed_init(ff, n, m);
   

--- a/tests/test_transpose.c
+++ b/tests/test_transpose.c
@@ -1,0 +1,119 @@
+#include "testing.h"
+
+int test_equality(gf2e *ff, rci_t m, rci_t n) {
+  int fail_ret = 0, bad_elem;
+  mzed_t *A0 = random_mzed_t(ff, m, n);
+  mzed_t *A1 = mzed_init(ff, n, m);
+  
+  mzed_t *A2 = mzed_copy(NULL, A0);
+  mzed_t *A3 = NULL;
+  
+  mzed_t *A4 = mzed_copy(NULL, A0);
+  mzed_t *A5 = mzed_copy(NULL, A1);
+  
+  mzed_t *A6 = mzed_copy(NULL, A0);
+  mzed_t *A7 = random_mzed_t(ff, n, m);
+  
+  mzed_set_canary(A1);
+  mzed_set_canary(A2);
+  mzed_set_canary(A4);
+  mzed_set_canary(A5);
+  mzed_set_canary(A6);
+  mzed_set_canary(A7);
+  
+  for (rci_t c = 0; c < A0->ncols; c++) {
+    for (rci_t r = 0; r < A0->nrows; r++) {
+      mzed_write_elem(A1, c, r, mzed_read_elem(A0, r, c));
+    }
+  }
+  A3 = mzed_transpose(A3, A2);
+  A5 = mzed_transpose(A5, A4);
+  A7 = mzed_transpose(A7, A6);
+  
+  m4rie_check( mzed_cmp(A0, A2) == 0);
+  m4rie_check( mzed_cmp(A0, A4) == 0);
+  m4rie_check( mzed_cmp(A0, A6) == 0);
+  m4rie_check( mzed_cmp(A1, A3) == 0);
+  m4rie_check( mzed_cmp(A1, A5) == 0);
+  m4rie_check( mzed_cmp(A1, A7) == 0);
+  
+  m4rie_check( mzed_canary_is_alive(A0) );
+  m4rie_check( mzed_canary_is_alive(A1) );
+  m4rie_check( mzed_canary_is_alive(A2) );
+  m4rie_check( mzed_canary_is_alive(A4) );
+  m4rie_check( mzed_canary_is_alive(A5) );
+  m4rie_check( mzed_canary_is_alive(A6) );
+  m4rie_check( mzed_canary_is_alive(A7) );
+  
+  mzed_free(A0);
+  mzed_free(A1);
+  mzed_free(A2);
+  mzed_free(A3);
+  mzed_free(A4);
+  mzed_free(A5);
+  mzed_free(A6);
+  mzed_free(A7);
+  
+  return fail_ret;
+}
+
+int test_batch(gf2e *ff, rci_t m, rci_t n) {
+  int fail_ret = 0;
+  printf("elim: k: %2d, minpoly: 0x%05x m: %5d, n: %5d ",(int)ff->degree, (unsigned int)ff->minpoly, (int)m, (int)n);
+
+  if(m == n) {
+    m4rie_check(   test_equality(ff, m, n) == 0); printf("."); fflush(0);
+    printf(" ");
+  } else {
+    m4rie_check(   test_equality(ff, m, n) == 0); printf("."); fflush(0);
+    m4rie_check(   test_equality(ff, n, m) == 0); printf("."); fflush(0);
+  }
+
+  if (fail_ret == 0)
+    printf(" passed\n");
+  else
+    printf(" FAILED\n");
+
+  return fail_ret;
+}
+
+int main(int argc, char **argv) {
+  srandom(17);
+
+  int runlong = parse_parameters(argc, argv);
+
+  gf2e *ff;
+  int fail_ret = 0;
+
+  for(int k=2; k<=16; k++) {
+    ff = gf2e_init(irreducible_polynomials[k][1]);
+
+    fail_ret += test_batch(ff,   2,   5);
+    fail_ret += test_batch(ff,   5,  10);
+    fail_ret += test_batch(ff,   1,   1);
+    fail_ret += test_batch(ff,   1,   2);
+    fail_ret += test_batch(ff,  11,  12);
+    fail_ret += test_batch(ff,  21,  22);
+    fail_ret += test_batch(ff,  13,   2);
+    fail_ret += test_batch(ff,  32,  33);
+    fail_ret += test_batch(ff,  63,  64);
+    if (k <= 12 || runlong) {
+      fail_ret += test_batch(ff, 127, 128);
+      fail_ret += test_batch(ff, 200,  20);
+    }
+    fail_ret += test_batch(ff,   1,   3);
+    fail_ret += test_batch(ff,  11,  13);
+    fail_ret += test_batch(ff,  21,  23);
+    fail_ret += test_batch(ff,  13,  90);
+    fail_ret += test_batch(ff,  32,  34);
+    fail_ret += test_batch(ff,  63,  65);
+    if (k <= 12 || runlong) {
+      fail_ret += test_batch(ff, 127, 129);
+      fail_ret += test_batch(ff, 200, 112);
+      fail_ret += test_batch(ff,  10, 200);
+    }
+    gf2e_free(ff);
+  }
+
+  return fail_ret;
+}


### PR DESCRIPTION
A fairly-optimised transpose function for matrices, as this is missing from Sage.

- Transfers are made in order of the data in the source matrix to reduce cache misses
- Buffers are used to reduce number of calls to __mzd_xor_bits, writes are done word by word
- Bulk reads are done on each word in memory to reduce calls to __mzd_read_bits, then masks and shifts are applied after

Tests and benchmarks added, now memory safe with a speedup of ~4.5-12x over naive transpose.